### PR TITLE
Fix reconnect functionality

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -191,8 +191,7 @@ class Client extends EventEmitter {
         delete this.nonceQueue[respNonce]
       } else {
         if (queueItem.action === 'sub') {
-          this._storeTopicMapping(queueItem.topic, queueItem.auth_token,
-                                  queueItem.handler)
+          this._storeTopicMapping(queueItem.topic, queueItem.handler, queueItem.auth_token)
           this.subscribedTopics.push(queueItem.topic)
           this.topicHandlers[queueItem.topic] = queueItem.handler
           delete this.nonceQueue[respNonce]


### PR DESCRIPTION
`_storeTopicMapping` was called with an invalid order of arguments, causing `auth_token` and `handler` to be switched. This resulted in issues during reconnect.